### PR TITLE
Убрал подключение polyfill.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,6 @@ extra_css:
   - stylesheets/extra7.css
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - https://cdn.jsdelivr.net/npm/vega@5
   - https://cdn.jsdelivr.net/npm/vega-lite@5


### PR DESCRIPTION
Почему: внешний polyfill-сервис тут не нужен, зато добавляет лишний сторонний скрипт на каждую страницу. Плюс polyfill.io исторически проблемный домен, можно почитать про то почему его тот же cloudflare редиректит.

А прямо сейчас, при заходе на сайт он кидает basic auth, из-за чего в браузере появляется лишнее окно авторизации. Поэтому просто выкинул эту строку из mkdocs.yml.